### PR TITLE
* contrib: don't hard depend on mountall

### DIFF
--- a/contrib/init.openrc
+++ b/contrib/init.openrc
@@ -10,8 +10,7 @@ required_dirs="/var/run"
 required_files="/etc/f2b/f2b.conf"
 
 depend() {
-  need mountall
-  use net
+  use mountall net
   after bootmisc
   config "/etc/f2b/f2b.conf"
 }


### PR DESCRIPTION
The mountall service is Debian specific, so it shouldn't be a hard
dependency. Change need mountall to use mountall instead. This makes the
init scrit compatible with Gentoo, and possibly other distros.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>